### PR TITLE
Fix: default to root deployment, fix CI test:unit and webServer setup

### DIFF
--- a/e2e/catalog.test.ts
+++ b/e2e/catalog.test.ts
@@ -1,10 +1,8 @@
 import { test, expect } from '@playwright/test'
 
-const BASE = '/jekyll-ttrpg-catalog'
-
 test.describe('catalog page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(`${BASE}/`)
+    await page.goto('/')
   })
 
   test('loads with cards visible', async ({ page }) => {
@@ -70,7 +68,7 @@ test.describe('catalog page', () => {
   })
 
   test('category URL param pre-filters results', async ({ page }) => {
-    await page.goto(`${BASE}/?category=monsters`)
+    await page.goto('/?category=monsters')
     const cards = page.locator('article.card')
     const total = await cards.count()
     expect(total).toBeGreaterThan(0)

--- a/e2e/resource.test.ts
+++ b/e2e/resource.test.ts
@@ -1,16 +1,14 @@
 import { test, expect } from '@playwright/test'
 
-const BASE = '/jekyll-ttrpg-catalog'
-
 test.describe('resource detail page', () => {
   test('renders the resource title and author', async ({ page }) => {
-    await page.goto(`${BASE}/resource/basilisk/`)
+    await page.goto('/resource/basilisk/')
     await expect(page.getByRole('heading', { level: 1 })).toContainText('Basilisk')
     await expect(page.getByText('Necrotic Gnome')).toBeVisible()
   })
 
   test('renders the source CTA link with correct href', async ({ page }) => {
-    await page.goto(`${BASE}/resource/into-the-odd/`)
+    await page.goto('/resource/into-the-odd/')
     const cta = page.getByRole('link', { name: /freeleague|source|get it/i })
     await expect(cta).toBeVisible()
     const href = await cta.getAttribute('href')
@@ -18,22 +16,22 @@ test.describe('resource detail page', () => {
   })
 
   test('back link returns to catalog', async ({ page }) => {
-    await page.goto(`${BASE}/resource/basilisk/`)
+    await page.goto('/resource/basilisk/')
     const backLink = page.getByRole('link', { name: /back|catalog|← /i })
     await expect(backLink).toBeVisible()
     await backLink.click()
-    await expect(page).toHaveURL(new RegExp(`${BASE}/?`))
+    await expect(page).toHaveURL(/\/$|\/\?/)
     await expect(page.locator('article.card').first()).toBeVisible()
   })
 
   test('renders cover image when cover-image is set', async ({ page }) => {
-    await page.goto(`${BASE}/resource/basilisk/`)
+    await page.goto('/resource/basilisk/')
     const img = page.getByRole('img', { name: /basilisk/i })
     await expect(img).toBeVisible()
   })
 
   test('renders local cover image correctly for into-the-odd', async ({ page }) => {
-    await page.goto(`${BASE}/resource/into-the-odd/`)
+    await page.goto('/resource/into-the-odd/')
     await expect(page.getByRole('heading', { level: 1 })).toContainText('Into the ODD')
     const img = page.getByRole('img')
     const src = await img.getAttribute('src')
@@ -41,11 +39,10 @@ test.describe('resource detail page', () => {
   })
 
   test('clicking a catalog card navigates to its resource page', async ({ page }) => {
-    await page.goto(`${BASE}/`)
+    await page.goto('/')
     const firstCardLink = page.locator('article.card').first().getByRole('link').first()
-    const linkHref = await firstCardLink.getAttribute('href')
     await firstCardLink.click()
-    await expect(page).toHaveURL(new RegExp(`${BASE}/resource/`))
+    await expect(page).toHaveURL(/\/resource\//)
     await expect(page.getByRole('heading', { level: 1 })).toBeVisible()
   })
 })

--- a/e2e/submit.test.ts
+++ b/e2e/submit.test.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '@playwright/test'
 
-const BASE = '/jekyll-ttrpg-catalog'
 
 test.describe('submission form', () => {
   test.beforeEach(async ({ page }) => {
@@ -17,7 +16,7 @@ test.describe('submission form', () => {
       }
     })
 
-    await page.goto(`${BASE}/submit/`)
+    await page.goto('/submit/')
   })
 
   test('renders required fields', async ({ page }) => {

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,11 +12,8 @@ const config = {
       precompress: false,
       strict: true,
     }),
-    // Set paths.base to your GitHub Pages repo path, e.g. '/my-repo-name'.
-    // Leave as '' for user/org GitHub Pages sites (username.github.io).
-    paths: {
-      base: '/jekyll-ttrpg-catalog',
-    },
+    // Set paths.base if deploying to a sub-path, e.g. '/my-repo-name' for
+    // GitHub Pages project sites. Leave unset (default '') for root deployments.
   },
 }
 


### PR DESCRIPTION
- Remove paths.base default — app now deploys at / by default; set paths.base in svelte.config.js for sub-path deployments (e.g. GitHub Pages project sites)
- Prepend svelte-kit sync to test:unit script so .svelte-kit/tsconfig.json exists before Vitest runs in CI
- Remove /jekyll-ttrpg-catalog prefix from all E2E test paths
- vite preview serves at / by default so Playwright webServer health check at http://localhost:4173 now resolves correctly