### PR TITLE
Feat: single basePath config cascades through SvelteKit, Playwright, and

### DIFF
--- a/catalog.config.js
+++ b/catalog.config.js
@@ -1,5 +1,11 @@
 /** @type {import('./src/lib/config.js').CatalogConfig} */
 export default {
+  // basePath: the sub-path https://gulluth.github.io/jekyll-ttrpg-catalog/resource/black-sword-hack/where your site is deployed.
+  // Set this to '/your-repo-name' for GitHub Pages project sites
+  // (userid.github.io/repo-name). Leave commented out for root deployments
+  // (userid.github.io or a custom domain at the root).
+  // basePath: '/jekyll-ttrpg-catalog',
+
   title: "Jekyll TTRPG Catalog",
   // description: "",
   // theme: "cerberus",   // cerberus | wintry | vintage | crimson | pine | modern
@@ -7,7 +13,7 @@ export default {
   // showSubmitForm: true,
   // showTagCloud: true,   // master toggle: pill-based filter UI — suits small collections
   // showFilterBar: true,  // master toggle: dropdown menu filter UI — suits large collections
-  //
+
   // filters: per-dimension overrides; takes precedence over master toggles above.
   // Each dimension can appear in the tag cloud, the dropdown menu, both, or neither.
   // Defaults shown below — omit the filters block to use defaults.
@@ -32,16 +38,12 @@ export default {
   // Add, remove, or rename entries to match your catalog's content structure.
   // This does NOT restrict what the app displays — posts in any category will
   // appear automatically. This list only controls what submitters can choose.
-  categories: [
-    "hacks",
-    "monsters",
-    "npcs",
-    "miscellany",
-  ],
+  categories: ["hacks", "monsters", "npcs", "miscellany"],
 
   // staticmanUrl: the Staticman API endpoint for community submissions.
   // Replace USERNAME, REPO, and BRANCH with your own values.
-  staticmanUrl: "https://staticman3.herokuapp.com/v3/entry/github/USERNAME/REPO/BRANCH/submissions",
+  staticmanUrl:
+    "https://staticman3.herokuapp.com/v3/entry/github/USERNAME/REPO/BRANCH/submissions",
 
   // customFields: define additional frontmatter fields specific to your catalog.
   // Each field is added to the resource page display and, if showSubmitForm is true,
@@ -66,4 +68,4 @@ export default {
   //   { key: "format",        label: "Format",        type: "text",   multiple: false },
   //   { key: "game_system",   label: "Game System",   type: "text",   multiple: true  },
   // ],
-}
+};

--- a/e2e/catalog.test.ts
+++ b/e2e/catalog.test.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test'
 
 test.describe('catalog page', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/')
+    await page.goto('.')
   })
 
   test('loads with cards visible', async ({ page }) => {
@@ -68,7 +68,7 @@ test.describe('catalog page', () => {
   })
 
   test('category URL param pre-filters results', async ({ page }) => {
-    await page.goto('/?category=monsters')
+    await page.goto('./?category=monsters')
     const cards = page.locator('article.card')
     const total = await cards.count()
     expect(total).toBeGreaterThan(0)

--- a/e2e/resource.test.ts
+++ b/e2e/resource.test.ts
@@ -2,13 +2,13 @@ import { test, expect } from '@playwright/test'
 
 test.describe('resource detail page', () => {
   test('renders the resource title and author', async ({ page }) => {
-    await page.goto('/resource/basilisk/')
+    await page.goto('./resource/basilisk/')
     await expect(page.getByRole('heading', { level: 1 })).toContainText('Basilisk')
     await expect(page.getByText('Necrotic Gnome')).toBeVisible()
   })
 
   test('renders the source CTA link with correct href', async ({ page }) => {
-    await page.goto('/resource/into-the-odd/')
+    await page.goto('./resource/into-the-odd/')
     const cta = page.getByRole('link', { name: /freeleague|source|get it/i })
     await expect(cta).toBeVisible()
     const href = await cta.getAttribute('href')
@@ -16,7 +16,7 @@ test.describe('resource detail page', () => {
   })
 
   test('back link returns to catalog', async ({ page }) => {
-    await page.goto('/resource/basilisk/')
+    await page.goto('./resource/basilisk/')
     const backLink = page.getByRole('link', { name: '← Back to catalog' })
     await expect(backLink).toBeVisible()
     await backLink.click()
@@ -25,13 +25,13 @@ test.describe('resource detail page', () => {
   })
 
   test('renders cover image when cover-image is set', async ({ page }) => {
-    await page.goto('/resource/basilisk/')
+    await page.goto('./resource/basilisk/')
     const img = page.getByRole('img', { name: /basilisk/i })
     await expect(img).toBeVisible()
   })
 
   test('renders local cover image correctly for into-the-odd', async ({ page }) => {
-    await page.goto('/resource/into-the-odd/')
+    await page.goto('./resource/into-the-odd/')
     await expect(page.getByRole('heading', { level: 1 })).toContainText('Into the ODD')
     const img = page.getByRole('img')
     const src = await img.getAttribute('src')
@@ -39,7 +39,7 @@ test.describe('resource detail page', () => {
   })
 
   test('clicking a catalog card navigates to its resource page', async ({ page }) => {
-    await page.goto('/')
+    await page.goto('.')
     const firstCardLink = page.locator('article.card').first().getByRole('link').first()
     await firstCardLink.click()
     await expect(page).toHaveURL(/\/resource\//)

--- a/e2e/submit.test.ts
+++ b/e2e/submit.test.ts
@@ -16,7 +16,7 @@ test.describe('submission form', () => {
       }
     })
 
-    await page.goto('/submit/')
+    await page.goto('./submit/')
   })
 
   test('renders required fields', async ({ page }) => {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,9 @@
 import { defineConfig, devices } from '@playwright/test'
+import catalogConfig from './catalog.config.js'
+
+const base: string = (catalogConfig as { basePath?: string }).basePath ?? ''
+const origin = 'http://localhost:4173'
+const baseURL = `${origin}${base}/`
 
 export default defineConfig({
   testDir: './e2e',
@@ -7,7 +12,7 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   reporter: 'html',
   use: {
-    baseURL: 'http://localhost:4173',
+    baseURL,
     trace: 'on-first-retry',
   },
   projects: [
@@ -28,7 +33,7 @@ export default defineConfig({
   ],
   webServer: {
     command: 'npm run preview',
-    url: 'http://localhost:4173',
+    url: baseURL,
     reuseExistingServer: !process.env.CI,
   },
 })

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -22,4 +22,5 @@ export interface CatalogConfig {
   categories: string[]
   customFields?: CustomField[]
   staticmanUrl?: string
+  basePath?: string
 }

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,5 +1,8 @@
 import adapter from '@sveltejs/adapter-static'
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
+import catalogConfig from './catalog.config.js'
+
+const base = catalogConfig.basePath ?? ''
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -12,8 +15,7 @@ const config = {
       precompress: false,
       strict: true,
     }),
-    // Set paths.base if deploying to a sub-path, e.g. '/my-repo-name' for
-    // GitHub Pages project sites. Leave unset (default '') for root deployments.
+    paths: { base },
   },
 }
 


### PR DESCRIPTION
E2E tests

Add `basePath` option to catalog.config.js (commented out by default). When set (e.g. '/jekyll-ttrpg-catalog' for a GitHub Pages project site), it flows automatically into svelte.config.js as paths.base and into playwright.config.ts as baseURL/webServer.url — no other files need touching. E2E page.goto() calls converted to relative paths ('.', './resource/...', './?param=value') so tests resolve correctly at any deployment root without modification.