### PR TITLE
Feat: filter layout improvements and global search (#16)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "jekyll-ttrpg-catalog",
       "version": "0.1.0",
       "dependencies": {
+        "@iconify-json/game-icons": "^1.2.4",
         "@skeletonlabs/skeleton-svelte": "^4.15.2",
         "lucide-svelte": "^1.0.0",
         "marked": "^18.0.2"
@@ -762,6 +763,21 @@
       "version": "0.2.11",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify-json/game-icons": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@iconify-json/game-icons/-/game-icons-1.2.4.tgz",
+      "integrity": "sha512-/HDDZxowXgDJcOEwPspUCq5RuDdl25OyZKdtxqqiPJQNTrWIym7r4StLzIVs77DyNzOWWhH5wDqwYR3WHeDfkg==",
+      "license": "CC-BY-3.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
       "license": "MIT"
     },
     "node_modules/@internationalized/date": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test": "npm run test:unit && npm run test:e2e"
   },
   "dependencies": {
+    "@iconify-json/game-icons": "^1.2.4",
     "@skeletonlabs/skeleton-svelte": "^4.15.2",
     "lucide-svelte": "^1.0.0",
     "marked": "^18.0.2"

--- a/src/lib/FilterBar.svelte
+++ b/src/lib/FilterBar.svelte
@@ -41,29 +41,29 @@
 {#if show}
 <div class="flex flex-wrap gap-2">
 
-  <select class="select" bind:value={category}>
+  <select class="select flex-1" bind:value={category}>
     <option value="all">All Categories</option>
     {#each categories as cat}<option value={cat}>{cat}</option>{/each}
   </select>
 
-  <select class="select" bind:value={author}>
+  <select class="select flex-1" bind:value={author}>
     <option value="all">All Authors</option>
     {#each authors as a}<option value={a}>{a}</option>{/each}
   </select>
 
-  <select class="select" bind:value={genre}>
+  <select class="select flex-1" bind:value={genre}>
     <option value="all">All Genres</option>
     {#each genres as g}<option value={g}>{g}</option>{/each}
   </select>
 
-  <select class="select" bind:value={cost}>
+  <select class="select flex-1" bind:value={cost}>
     <option value="all">All Costs</option>
     {#each costs as c}<option value={c}>{c}</option>{/each}
   </select>
 
   <div class="flex items-center gap-2 ml-auto">
     <label for="sort-select" class="text-xs opacity-60 whitespace-nowrap">Sort by</label>
-    <select id="sort-select" class="select text-sm" bind:value={sort}>
+    <select id="sort-select" class="select w-auto text-sm" bind:value={sort}>
       <option value="newest">Newest</option>
       <option value="oldest">Oldest</option>
       <option value="az">A–Z</option>
@@ -71,11 +71,16 @@
     </select>
   </div>
 
-  {#if isDirty}
-  <button onclick={clearAll} class="btn preset-outlined text-xs">
-    Clear filters
+  <button
+    onclick={clearAll}
+    disabled={!isDirty}
+    aria-label="Clear filters"
+    class="shrink-0 transition-colors {isDirty ? 'text-success-500 hover:text-success-400 cursor-pointer' : 'text-surface-400 cursor-not-allowed'}"
+  >
+    <svg width="28" height="28" viewBox="0 0 512 512" fill="currentColor" aria-hidden="true">
+      <path d="m153.654 18l52.57 134.734c1.698 3.994 4.05 5.83 7.243 6.977c3.2 1.15 7.36 1.2 11.058.17s6.71-3.146 7.996-4.915c1.288-1.77 1.634-2.564.505-5.24l-.046-.112L181.57 18zm94.168 120.143l1.88 4.81l-.09-.223c3.346 7.937 1.828 16.822-2.532 22.82c-4.36 5.996-10.773 9.734-17.723 11.67c-6.95 1.937-14.653 2.065-21.98-.57s-14.155-8.447-17.742-16.923l-.05-.118l-1.757-4.5c-31.31 19.804-42.47 42.026-35.367 68.89c1.24 4.681 3.422 12.364 5.964 22.13c74.37-5.274 139.945-23.872 199.808-51.6c-10.297-13.867-22.5-25.83-38.232-34.53c-20.505-11.34-47.652-20.157-72.178-21.857zm120.557 71.52c-61.497 28.81-129.173 48.378-205.575 54.196c2.03 8.683 4.08 18.28 5.95 28.495c89.592-10.084 163.043-26.22 217.755-48.767c-5.743-11.72-11.593-23.19-18.13-33.924m26.04 50.16c-57.093 23.772-131.99 40.087-222.73 50.322C180.697 371.423 179.614 446.752 128 480c16.27 0 31.892-.152 46.926-.45c17.84-25.554 31.27-66.222 32.08-86.146c8.27 16.793 3.297 59.32-5.36 85.434c2.735-.093 5.435-.193 8.127-.297c11.824-12.397 11.724-28.632 14.72-47.284c3.324 14.92 7 32.967 9.505 46.156c11.273-.616 22.152-1.34 32.606-2.183c16.38-20.358 21.65-49.604 18.63-85.48c4.226 29.1 9.116 62.138 11.873 82.55a772 772 0 0 0 27.807-3.614c5.04-18.787-4.1-48.444-2.072-69.54c11.123 43.113 22.247 55.45 33.37 64.043a456 456 0 0 0 15.733-3.526c-4.7-13.95 1.573-22.497 1.18-39.986c5.647 18.99 14.625 26.958 24.428 32.816c6.506-2.1 12.66-4.336 18.492-6.697c-10.538-6.57-10.113-26.374-12.38-42.926c5.954 21.703 14.413 32.418 24.083 37.816c29.124-13.8 48.69-31.534 60.398-53.657c-9.078-3.82-18.674-13.002-28.068-20.092c13.214 7.477 23.684 10.614 32.37 10.93a112 112 0 0 0 3.552-9.868c-56.326-19.528-80.07-64.018-101.58-108.178z"/>
+    </svg>
   </button>
-  {/if}
 
 </div>
 {/if}

--- a/src/lib/FilterBar.test.ts
+++ b/src/lib/FilterBar.test.ts
@@ -28,25 +28,25 @@ test('renders all four filter selects and sort select when show is true', () => 
   expect(screen.getByLabelText('Sort by')).toBeInTheDocument()
 })
 
-test('Clear filters button hidden when nothing is dirty', () => {
+test('Clear filters button is disabled when nothing is dirty', () => {
   render(FilterBar, baseProps)
-  expect(screen.queryByText('Clear filters')).not.toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Clear filters' })).toBeDisabled()
 })
 
-test('Clear filters button shown when a filter is non-default', () => {
+test('Clear filters button is enabled when a filter is non-default', () => {
   render(FilterBar, { ...baseProps, category: 'hacks' })
-  expect(screen.getByText('Clear filters')).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Clear filters' })).not.toBeDisabled()
 })
 
-test('Clear filters button shown when sort is non-default', () => {
+test('Clear filters button is enabled when sort is non-default', () => {
   render(FilterBar, { ...baseProps, sort: 'az' as const })
-  expect(screen.getByText('Clear filters')).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: 'Clear filters' })).not.toBeDisabled()
 })
 
 test('clicking Clear filters resets selects to default values', async () => {
   render(FilterBar, { ...baseProps, category: 'hacks', sort: 'az' as const })
-  await fireEvent.click(screen.getByText('Clear filters'))
-  expect(screen.queryByText('Clear filters')).not.toBeInTheDocument()
+  await fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }))
+  expect(screen.getByRole('button', { name: 'Clear filters' })).toBeDisabled()
 })
 
 test('sort select has all four options', () => {

--- a/src/lib/SearchInput.svelte
+++ b/src/lib/SearchInput.svelte
@@ -2,7 +2,7 @@
   let { value = $bindable('') }: { value: string } = $props()
 </script>
 
-<div class="input-group grid-cols-[1fr_auto] w-full max-w-md">
+<div class="input-group grid-cols-[1fr_auto] w-full">
   <input
     id="jekyll-ttrpg-catalog-search"
     type="search"

--- a/src/lib/search.svelte.ts
+++ b/src/lib/search.svelte.ts
@@ -1,0 +1,1 @@
+export const searchState = $state({ query: '' })

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,8 @@
     import "../app.css";
     import { base } from "$app/paths";
     import { config } from "$lib/catalog.js";
+    import { searchState } from "$lib/search.svelte.js";
+    import SearchInput from "$lib/SearchInput.svelte";
 
     const { children } = $props();
 
@@ -28,6 +30,9 @@
         >
             {config.title}
         </a>
+        <div class="flex-1 max-w-sm">
+            <SearchInput bind:value={searchState.query} />
+        </div>
         <div class="ml-auto flex items-center gap-3">
             {#if config.showSubmitForm}
                 <a

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,15 +3,14 @@
   import { replaceState } from '$app/navigation'
   import { applySearch, applyFilters, sortPosts, paginate } from '$lib/filters.js'
   import type { SortOption } from '$lib/filters.js'
+  import { searchState } from '$lib/search.svelte.js'
   import CardGrid from '$lib/CardGrid.svelte'
   import FilterBar from '$lib/FilterBar.svelte'
-  import SearchInput from '$lib/SearchInput.svelte'
   import TagCloud from '$lib/TagCloud.svelte'
   import Pagination from '$lib/Pagination.svelte'
 
   const { data } = $props()
 
-  let search = $state('')
   let filterCategory = $state('all')
   let filterAuthor = $state('all')
   let filterGenre = $state('all')
@@ -22,7 +21,7 @@
 
   onMount(() => {
     const p = new URLSearchParams(window.location.search)
-    search = p.get('q') ?? ''
+    searchState.query = p.get('q') ?? ''
     filterCategory = p.get('category') ?? 'all'
     filterAuthor = p.get('author') ?? 'all'
     filterGenre = p.get('genre') ?? 'all'
@@ -33,7 +32,7 @@
 
   // Reset to page 1 whenever filter/search/sort state changes
   const filterKey = $derived(
-    `${search}|${filterCategory}|${filterAuthor}|${filterGenre}|${filterCost}|${sort}`
+    `${searchState.query}|${filterCategory}|${filterAuthor}|${filterGenre}|${filterCost}|${sort}`
   )
   $effect(() => {
     filterKey
@@ -44,7 +43,7 @@
   $effect(() => {
     if (!mounted) return
     const p = new URLSearchParams()
-    if (search) p.set('q', search)
+    if (searchState.query) p.set('q', searchState.query)
     if (filterCategory !== 'all') p.set('category', filterCategory)
     if (filterAuthor !== 'all') p.set('author', filterAuthor)
     if (filterGenre !== 'all') p.set('genre', filterGenre)
@@ -56,7 +55,7 @@
 
   const filtered = $derived(
     applyFilters(
-      applySearch(data.posts, search),
+      applySearch(data.posts, searchState.query),
       { category: filterCategory, author: filterAuthor, genre: filterGenre, cost: filterCost }
     )
   )
@@ -68,8 +67,6 @@
 
 <div class="px-4 py-6 max-w-7xl mx-auto">
   <div class="flex flex-col gap-3 mb-6">
-    <SearchInput bind:value={search} />
-
     <TagCloud
       categories={data.categories}
       bind:selected={filterCategory}


### PR DESCRIPTION
- Move search input to header via shared search.svelte.ts state, available on all pages; removed from catalog page body
- Filter dropdowns now sit in a single row on desktop (flex-1 gives consistent equal widths); SearchInput no longer caps at max-w-md
- Replace conditional "Clear filters" button with a persistent broom icon (game-icons) — green when active, muted when no filters are set, no layout shift on appear/disappear
- Add @iconify-json/game-icons for SVG icon data