### PR TITLE
Fix: Search navigation bug

### DIFF
--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -1,30 +1,35 @@
-<script lang="ts">
-  import { onMount } from 'svelte'
-  import { afterNavigate } from '$app/navigation'
-  import { base } from '$app/paths'
-
+<script lang="ts" module>
   interface PagefindResult {
     url: string
     excerpt: string
     meta: { title?: string }
   }
 
+  // Singleton — survives route changes so Pagefind is only imported once
+  let pagefind: {
+    search: (q: string) => Promise<{ results: { data: () => Promise<PagefindResult> }[] }>
+    options: (o: object) => Promise<void>
+  } | null = null
+</script>
+
+<script lang="ts">
+  import { afterNavigate } from '$app/navigation'
+  import { base } from '$app/paths'
+
   let query = $state('')
   let results = $state<PagefindResult[]>([])
   let loading = $state(false)
   let unavailable = $state(false)
 
-  let pagefindModule: { search: (q: string) => Promise<{ results: { data: () => Promise<PagefindResult> }[] }>, options: (o: object) => Promise<void> } | null = null
-
   async function runSearch(q: string) {
     if (!q) { results = []; return }
     loading = true
     try {
-      if (!pagefindModule) {
-        pagefindModule = await import(/* @vite-ignore */ `${base}/pagefind/pagefind.js`)
-        if (base) await pagefindModule!.options({ baseUrl: base })
+      if (!pagefind) {
+        pagefind = await import(/* @vite-ignore */ `${base}/pagefind/pagefind.js`)
+        if (base) await pagefind!.options({ baseUrl: base })
       }
-      const search = await pagefindModule!.search(q)
+      const search = await pagefind!.search(q)
       results = await Promise.all(search.results.map(r => r.data()))
     } catch {
       unavailable = true
@@ -33,14 +38,12 @@
     }
   }
 
-  function readQuery() {
-    query = new URLSearchParams(window.location.search).get('q') ?? ''
-  }
-
-  onMount(readQuery)
-  afterNavigate(readQuery)
-
-  $effect(() => { runSearch(query) })
+  // afterNavigate fires on initial mount AND on subsequent navigations to this route
+  afterNavigate(() => {
+    const q = new URLSearchParams(window.location.search).get('q') ?? ''
+    query = q
+    runSearch(q)
+  })
 </script>
 
 <svelte:head>


### PR DESCRIPTION
The issue is the $effect triggering runSearch as an async operation. When Svelte 5 re-runs or cleans up the effect while the async import/search is in flight, it can corrupt internal signal state, causing the $set error. Also, pagefindModule being instance-scoped means it’s null again every time the user navigates back to search.

The fix: remove $effect, use only afterNavigate (which fires on initial mount too), and hoist the Pagefind module to module scope as a singleton.