### PR TITLE
Fix: console errors after search integration

### DIFF
--- a/src/lib/SearchInput.svelte
+++ b/src/lib/SearchInput.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { goto } from '$app/navigation'
   import { base } from '$app/paths'
 
   let query = $state('')
@@ -7,7 +6,7 @@
   function handleSubmit(e: Event) {
     e.preventDefault()
     if (query.trim()) {
-      goto(`${base}/search/?q=${encodeURIComponent(query.trim())}`)
+      window.location.assign(`${base}/search/?q=${encodeURIComponent(query.trim())}`)
     }
   }
 </script>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { onMount, untrack } from 'svelte'
-  import { replaceState } from '$app/navigation'
   import { applyFilters, sortPosts, paginate } from '$lib/filters.js'
   import type { SortOption } from '$lib/filters.js'
   import CardGrid from '$lib/CardGrid.svelte'
@@ -47,7 +46,7 @@
     if (filterCost !== 'all') p.set('cost', filterCost)
     if (sort !== 'newest') p.set('sort', sort)
     const qs = p.toString()
-    replaceState(qs ? `?${qs}` : '?', {})
+    history.replaceState(history.state, '', qs ? `?${qs}` : location.pathname)
   })
 
   const filtered = $derived(


### PR DESCRIPTION
- **Submit E2E tests** — fixed selector from `button[type="submit"]` to `getByRole('button', { name: 'Submit Resource' })`
- **Search SPA navigation** — `window.location.assign()` instead of `goto()` in `SearchInput.svelte`
- **`$set` console error on page load** — native `history.replaceState` instead of SvelteKit's `replaceState` in `+page.svelte`, avoiding the `jt.$set()` call before `jt` is assigned