### PR TITLE
Feat: add RSS autodiscovery link to document head

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,6 +19,10 @@
     }
 </script>
 
+<svelte:head>
+    <link rel="alternate" type="application/rss+xml" title={config.title} href="{base}/feed.xml" />
+</svelte:head>
+
 <div data-theme={config.theme} class="min-h-screen flex flex-col">
     <header
         class="border-b border-surface-200-800 px-4 py-3 grid grid-cols-[1fr_auto_1fr] items-center gap-4"


### PR DESCRIPTION
Adds <link rel="alternate" type="application/rss+xml"> to the root layout so browsers can detect the feed and display it in the address bar. Placed in +layout.svelte (not app.html) to have access to base path and config.title.