### PR TITLE
Task: wire up npm package — CLI, bin, files, publish workflow #8

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish to GitHub Packages
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@girtablu'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Unit tests
+        run: npm run test:unit
+
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@girtablu:registry=https://npm.pkg.github.com

--- a/package.json
+++ b/package.json
@@ -1,8 +1,18 @@
 {
-  "name": "gorlab",
+  "name": "@girtablu/gorlab",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "type": "module",
+  "bin": {
+    "gorlab": "./scripts/cli.js"
+  },
+  "files": [
+    "src/",
+    "scripts/",
+    "starter-template/",
+    "svelte.config.js",
+    "vite.config.ts"
+  ],
   "scripts": {
     "prepare": "svelte-kit sync",
     "clean": "rm -rf build .svelte-kit",
@@ -16,29 +26,28 @@
     "test": "npm run test:unit && npm run test:e2e"
   },
   "dependencies": {
-    "@iconify-json/game-icons": "^1.2.4",
-    "@skeletonlabs/skeleton-svelte": "^4.15.2",
-    "lucide-svelte": "^1.0.0",
-    "marked": "^18.0.2"
-  },
-  "devDependencies": {
-    "@playwright/test": "^1.59.1",
     "@skeletonlabs/skeleton": "^4.15.2",
+    "@skeletonlabs/skeleton-svelte": "^4.15.2",
     "@sveltejs/adapter-static": "^3.0.10",
     "@sveltejs/kit": "^2.58.0",
     "@sveltejs/vite-plugin-svelte": "^5.0.0",
     "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/vite": "^4.0.0",
-    "@testing-library/jest-dom": "^6.9.1",
-    "@testing-library/svelte": "^5.3.1",
-    "@types/node": "^25.6.0",
     "gray-matter": "^4.0.3",
-    "jsdom": "^29.1.0",
+    "lucide-svelte": "^1.0.0",
+    "marked": "^18.0.2",
     "pagefind": "^1.5.2",
     "svelte": "^5.0.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0",
-    "vite": "^6.0.0",
+    "vite": "^6.0.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.59.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/svelte": "^5.3.1",
+    "@types/node": "^25.6.0",
+    "jsdom": "^29.1.0",
     "vitest": "^4.1.5"
   }
 }

--- a/scripts/cli.js
+++ b/scripts/cli.js
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+import { spawnSync } from 'child_process'
+import { cpSync, rmSync, existsSync, readdirSync, mkdirSync, copyFileSync } from 'fs'
+import { resolve, dirname, join, relative } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const packageRoot = resolve(__dirname, '..')
+const cwd = process.cwd()
+
+// Files extracted into the user's project at build/dev time — removed afterwards
+const EPHEMERAL = ['src', 'svelte.config.js', 'vite.config.ts']
+
+function extract() {
+  for (const item of EPHEMERAL) {
+    cpSync(join(packageRoot, item), join(cwd, item), { recursive: true, force: true })
+  }
+}
+
+function cleanup() {
+  for (const item of EPHEMERAL) {
+    rmSync(join(cwd, item), { recursive: true, force: true })
+  }
+}
+
+function resolveBin(name) {
+  for (const base of [cwd, packageRoot]) {
+    const p = join(base, 'node_modules', '.bin', name)
+    if (existsSync(p)) return p
+  }
+  return name
+}
+
+function run(bin, args = []) {
+  const result = spawnSync(resolveBin(bin), args, { stdio: 'inherit', cwd })
+  if (result.status !== 0 && result.status !== null) {
+    throw new Error(`${bin} exited with code ${result.status}`)
+  }
+}
+
+const [,, command] = process.argv
+
+switch (command) {
+  case 'build': {
+    extract()
+    try {
+      run('svelte-kit', ['sync'])
+      run('vite', ['build'])
+      const pagefindResult = spawnSync(
+        resolveBin('pagefind'),
+        ['--site', 'build', '--glob', 'resource/**/*.html'],
+        { stdio: 'inherit', cwd }
+      )
+      if (pagefindResult.status === 0) {
+        cpSync(join(cwd, 'build', 'pagefind'), join(cwd, '.svelte-kit', 'output', 'client', 'pagefind'), { recursive: true, force: true })
+      } else {
+        console.log('No resource pages — search index skipped')
+      }
+    } finally {
+      cleanup()
+    }
+    break
+  }
+
+  case 'dev': {
+    extract()
+    try {
+      run('vite', ['dev'])
+    } finally {
+      cleanup()
+    }
+    break
+  }
+
+  case 'preview': {
+    run('vite', ['preview'])
+    break
+  }
+
+  case 'init': {
+    const templateDir = join(packageRoot, 'starter-template')
+
+    function copyDir(src, dest) {
+      mkdirSync(dest, { recursive: true })
+      for (const entry of readdirSync(src, { withFileTypes: true })) {
+        const srcPath = join(src, entry.name)
+        const destPath = join(dest, entry.name)
+        if (entry.isDirectory()) {
+          copyDir(srcPath, destPath)
+        } else if (existsSync(destPath)) {
+          console.log(`Skipping existing file: ${relative(cwd, destPath)}`)
+        } else {
+          mkdirSync(dirname(destPath), { recursive: true })
+          copyFileSync(srcPath, destPath)
+          console.log(`Writing: ${relative(cwd, destPath)}`)
+        }
+      }
+    }
+
+    copyDir(templateDir, cwd)
+    console.log('\nDone! Next steps:\n  npm install\n  npm run dev')
+    break
+  }
+
+  default:
+    console.error('Usage: gorlab <build|dev|preview|init>')
+    process.exit(1)
+}

--- a/starter-template/.github/workflows/build.yml
+++ b/starter-template/.github/workflows/build.yml
@@ -24,9 +24,13 @@ jobs:
         with:
           node-version: '20'
           cache: 'npm'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@girtablu'
 
       - name: Install dependencies
         run: npm install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         run: npm run build

--- a/starter-template/.gitignore
+++ b/starter-template/.gitignore
@@ -1,4 +1,6 @@
 /src
+/svelte.config.js
+/vite.config.ts
 /.svelte-kit
 /build
 /node_modules

--- a/starter-template/.npmrc
+++ b/starter-template/.npmrc
@@ -1,0 +1,1 @@
+@girtablu:registry=https://npm.pkg.github.com


### PR DESCRIPTION
Implements NPM Package #8 

- Rename package to @girtablu/gorlab, private: false
- Add bin.gorlab → scripts/cli.js (build/dev/preview/init commands)
- Add files field listing src/, scripts/, starter-template/, svelte.config.js, vite.config.ts
- Move build tools (svelte, vite, @sveltejs/kit, tailwindcss, pagefind, etc.) from devDependencies to dependencies
- Add .npmrc scoping @girtablu to GitHub Packages
- Update starter-template: authenticate npm install in CI, .npmrc scope, ephemeral files in .gitignore