### PR TITLE
Fix: add @source '../' to app.css for Tailwind v4 content scanning

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,5 +1,6 @@
 @import 'tailwindcss';
 @plugin '@tailwindcss/forms';
+@source '../';
 
 @import '@skeletonlabs/skeleton';
 /* Bundled preset themes — switch via jtc.theme in _config.yml */


### PR DESCRIPTION
Without an explicit @source directive, Tailwind v4's Vite plugin did not scan the extracted Svelte component files when building from a user project directory. This caused utility classes (grid, flex, etc.) to be omitted from the compiled CSS, leaving the site visually unstyled.