### PR TITLE
bugfix: store raw cover-image path in pagefind meta

### DIFF
--- a/src/routes/resource/[slug]/+page.svelte
+++ b/src/routes/resource/[slug]/+page.svelte
@@ -48,7 +48,7 @@
     <meta data-pagefind-meta="summary[content]" content={post.summary}>
   {/if}
   {#if hasCover}
-    <meta data-pagefind-meta="cover-image[content]" content={coverSrc}>
+    <meta data-pagefind-meta="cover-image[content]" content={post['cover-image']}>
   {/if}
   <meta data-pagefind-meta="featured[content]" content={String(post.featured)}>
   {#if post.category.length > 0}


### PR DESCRIPTION
When basePath is set, coverSrc already includes the base prefix. Storing coverSrc in pagefind caused ResourceCard to prepend base a second time on the landing page, producing a double-prefix 404.