### PR TITLE
bugfix: index imageOrientation in Pagefind so card overrides take effect

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,7 @@
   import { onMount, untrack } from 'svelte'
   import { base } from '$app/paths'
   import type { Post } from '$lib/posts.js'
+  import type { ImageOrientation } from '$lib/config.js'
   import CardGrid from '$lib/CardGrid.svelte'
   import FilterBar from '$lib/FilterBar.svelte'
   import TagCloud from '$lib/TagCloud.svelte'
@@ -20,6 +21,7 @@
     author?: string
     cost?: string
     date?: string
+    imageOrientation?: string
   }
 
   interface PagefindResultData {
@@ -74,7 +76,7 @@
       body: '',
       featured: r.meta.featured === 'true',
       sort_priority: null,
-      imageOrientation: null,
+      imageOrientation: (r.meta.imageOrientation as ImageOrientation) ?? null,
       meta: {},
     }
   }

--- a/src/routes/resource/[slug]/+page.svelte
+++ b/src/routes/resource/[slug]/+page.svelte
@@ -64,6 +64,9 @@
     <meta data-pagefind-sort="sort_priority[content]" content={String(post.sort_priority)}>
   {/if}
   <meta data-pagefind-meta="date[content]" content={post.date}>
+  {#if post.imageOrientation}
+    <meta data-pagefind-meta="imageOrientation[content]" content={post.imageOrientation}>
+  {/if}
 </svelte:head>
 
 {#snippet coverImage(classes: string)}


### PR DESCRIPTION
resultToPost() always hardcoded imageOrientation: null because the field was never emitted as a data-pagefind-meta attribute. ResourceCard's `post.imageOrientation ?? config.imageOrientation` therefore always fell back to the global config default, ignoring any per-card frontmatter value.

Added the meta tag to the resource detail template so Pagefind captures the value at build time, and updated resultToPost() to read it back.