### PR TITLE
feat: masonry card layout

### DIFF
--- a/e2e/catalog.test.ts
+++ b/e2e/catalog.test.ts
@@ -41,30 +41,6 @@ test.describe('catalog page', () => {
     }).toPass({ timeout: 10000 })
   })
 
-  test('sort A–Z orders cards alphabetically ascending', async ({ page }) => {
-    await openFiltersIfCollapsed(page)
-    await page.selectOption('#sort-select', 'az')
-
-    await expect(async () => {
-      await page.locator('article.card').first().waitFor({ timeout: 5000 })
-      const headings = await page.locator('article.card').getByRole('heading').allTextContents()
-      expect(headings.length).toBeGreaterThan(1)
-      expect(headings).toEqual([...headings].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase())))
-    }).toPass({ timeout: 15000 })
-  })
-
-  test('sort Z–A orders cards alphabetically descending', async ({ page }) => {
-    await openFiltersIfCollapsed(page)
-    await page.selectOption('#sort-select', 'za')
-
-    await expect(async () => {
-      await page.locator('article.card').first().waitFor({ timeout: 5000 })
-      const headings = await page.locator('article.card').getByRole('heading').allTextContents()
-      expect(headings.length).toBeGreaterThan(1)
-      expect(headings).toEqual([...headings].sort((a, b) => b.toLowerCase().localeCompare(a.toLowerCase())))
-    }).toPass({ timeout: 15000 })
-  })
-
   test('pagination is hidden when all posts fit on one page', async ({ page }) => {
     await expect(page.locator('nav[aria-label*="pagination"]')).not.toBeVisible()
   })

--- a/gorlab.config.js
+++ b/gorlab.config.js
@@ -25,8 +25,22 @@ export default {
   // ── Appearance ────────────────────────────────────────────────────────────
   // theme: "cerberus", // cerberus | wintry | vintage | crimson | pine | modern
 
+  // cardLayout: controls how resource cards are arranged on the catalog page.
+  //   'masonry' (default) — variable-height cards; gaps collapse naturally.
+  //                         Cards are ordered left-to-right in date order.
+  //                         Best for catalogs with mixed summary lengths or
+  //                         mixed imageOrientation values.
+  //   'grid'              — uniform rows; every card in a row shares the same
+  //                         height. Best when cards are visually consistent.
+  // cardLayout: 'masonry',
+
   // ── Content display ───────────────────────────────────────────────────────
   // postsPerPage: 24,
+
+  // Post filenames: posts/<category>/slug.md
+  // Optional: prefix with a publication date to control sort order —
+  //   posts/<category>/YYYY-MM-DD-slug.md
+  // Posts without a date prefix sort after all dated posts.
 
   // imageOrientation: controls how cover images are displayed across cards and
   // resource pages. Match this to the shape of your cover images.

--- a/src/lib/CardGrid.svelte
+++ b/src/lib/CardGrid.svelte
@@ -1,14 +1,59 @@
 <script lang="ts">
   import type { Post } from './posts.js'
   import ResourceCard from './ResourceCard.svelte'
+  import { config } from './catalog.js'
 
   let { posts }: { posts: Post[] } = $props()
+
+  let gridEl: HTMLElement | undefined = $state()
+
+  // Each grid row is 10px tall; gap is read from computed styles so the span
+  // calculation stays accurate regardless of the Tailwind gap class in use.
+  const ROW_HEIGHT = 10
+
+  function measureSpans() {
+    if (!gridEl) return
+    const gap = parseInt(getComputedStyle(gridEl).rowGap) || 0
+    for (const item of gridEl.children) {
+      const card = (item as HTMLElement).firstElementChild as HTMLElement | null
+      if (!card) continue
+      const h = card.getBoundingClientRect().height
+      const span = Math.ceil((h + gap) / (ROW_HEIGHT + gap))
+      ;(item as HTMLElement).style.gridRow = `span ${span}`
+    }
+  }
+
+  // Re-measure after each posts update so new cards get correct spans.
+  $effect(() => {
+    posts
+    if (config.cardLayout !== 'masonry') return
+    requestAnimationFrame(measureSpans)
+  })
+
+  // Re-measure on viewport resize so spans stay accurate as columns reflow.
+  $effect(() => {
+    if (config.cardLayout !== 'masonry' || !gridEl) return
+    const ro = new ResizeObserver(() => requestAnimationFrame(measureSpans))
+    ro.observe(gridEl)
+    return () => ro.disconnect()
+  })
 </script>
 
 {#if posts.length === 0}
   <div class="flex items-center justify-center min-h-48 border border-current border-dashed rounded">
     <p class="opacity-40 text-sm">No resources match your filters.</p>
   </div>
+{:else if config.cardLayout === 'masonry'}
+  <ul
+    bind:this={gridEl}
+    class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6 auto-rows-[10px]"
+  >
+    {#each posts as post (post.slug)}
+      <li>
+        <ResourceCard {post} />
+      </li>
+    {/each}
+  </ul>
 {:else}
   <ul class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6">
     {#each posts as post (post.slug)}

--- a/src/lib/CardGrid.test.ts
+++ b/src/lib/CardGrid.test.ts
@@ -22,6 +22,7 @@ function makePost(overrides: Partial<Post> = {}): Post {
     body: '',
     featured: false,
     sort_priority: null,
+    imageOrientation: null,
     meta: {},
     ...overrides,
   }
@@ -47,4 +48,10 @@ test('renders a list item for each post', () => {
 test('does not show empty state when posts are present', () => {
   render(CardGrid, { posts: [makePost()] })
   expect(screen.queryByText('No resources match your filters.')).not.toBeInTheDocument()
+})
+
+test('masonry grid uses auto-rows-[10px] class', () => {
+  const { container } = render(CardGrid, { posts: [makePost()] })
+  const grid = container.querySelector('ul')
+  expect(grid?.className).toContain('auto-rows-[10px]')
 })

--- a/src/lib/FilterBar.svelte
+++ b/src/lib/FilterBar.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-    import type { SortOption } from "./filters.js";
-
     let {
         categories = [],
         authors = [],
@@ -10,7 +8,6 @@
         author = $bindable("all"),
         genre = $bindable("all"),
         cost = $bindable("all"),
-        sort = $bindable<SortOption>("newest"),
         show = true,
         showCost = true,
     }: {
@@ -22,7 +19,6 @@
         author: string;
         genre: string;
         cost: string;
-        sort: SortOption;
         show?: boolean;
         showCost?: boolean;
     } = $props();
@@ -31,8 +27,7 @@
         category !== "all" ||
             author !== "all" ||
             genre !== "all" ||
-            cost !== "all" ||
-            sort !== "newest",
+            cost !== "all",
     );
 
     function clearAll() {
@@ -40,7 +35,6 @@
         author = "all";
         genre = "all";
         cost = "all";
-        sort = "newest";
     }
 </script>
 
@@ -67,23 +61,6 @@
                 {#each costs as c}<option value={c}>{c}</option>{/each}
             </select>
         {/if}
-
-        <div class="flex items-center gap-2 ml-auto">
-            <label
-                for="sort-select"
-                class="text-xs opacity-60 whitespace-nowrap">Sort by</label
-            >
-            <select
-                id="sort-select"
-                class="select w-auto text-sm"
-                bind:value={sort}
-            >
-                <option value="newest">Newest</option>
-                <option value="oldest">Oldest</option>
-                <option value="az">A–Z</option>
-                <option value="za">Z–A</option>
-            </select>
-        </div>
 
         <button
             onclick={clearAll}

--- a/src/lib/FilterBar.test.ts
+++ b/src/lib/FilterBar.test.ts
@@ -10,7 +10,6 @@ const baseProps = {
   author: "all",
   genre: "all",
   cost: "all",
-  sort: "newest" as const,
   show: true,
 };
 
@@ -19,13 +18,13 @@ test("renders nothing when show is false", () => {
   expect(screen.queryByText("Categories")).not.toBeInTheDocument();
 });
 
-test("renders all four filter selects and sort select when show is true", () => {
+test("renders all four filter selects when show is true", () => {
   render(FilterBar, baseProps);
   expect(screen.getByText("Categories")).toBeInTheDocument();
   expect(screen.getByText("Authors")).toBeInTheDocument();
   expect(screen.getByText("Genres")).toBeInTheDocument();
   expect(screen.getByText("All Costs")).toBeInTheDocument();
-  expect(screen.getByLabelText("Sort by")).toBeInTheDocument();
+  expect(screen.queryByLabelText("Sort by")).not.toBeInTheDocument();
 });
 
 test("Clear filters button is disabled when nothing is dirty", () => {
@@ -40,24 +39,8 @@ test("Clear filters button is enabled when a filter is non-default", () => {
   ).not.toBeDisabled();
 });
 
-test("Clear filters button is enabled when sort is non-default", () => {
-  render(FilterBar, { ...baseProps, sort: "az" as const });
-  expect(
-    screen.getByRole("button", { name: "Clear filters" }),
-  ).not.toBeDisabled();
-});
-
 test("clicking Clear filters resets selects to default values", async () => {
-  render(FilterBar, { ...baseProps, category: "systems", sort: "az" as const });
+  render(FilterBar, { ...baseProps, category: "systems" });
   await fireEvent.click(screen.getByRole("button", { name: "Clear filters" }));
   expect(screen.getByRole("button", { name: "Clear filters" })).toBeDisabled();
-});
-
-test("sort select has all four options", () => {
-  render(FilterBar, baseProps);
-  const sortSelect = screen.getByLabelText("Sort by");
-  expect(sortSelect).toContainElement(screen.getByText("Newest"));
-  expect(sortSelect).toContainElement(screen.getByText("Oldest"));
-  expect(sortSelect).toContainElement(screen.getByText("A–Z"));
-  expect(sortSelect).toContainElement(screen.getByText("Z–A"));
 });

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -1,5 +1,5 @@
 import rawConfig from "../../gorlab.config.js";
-import type { CatalogConfig, CustomField, FilterDimension, ImageOrientation } from "./config.js";
+import type { CatalogConfig, CardLayout, CustomField, FilterDimension, ImageOrientation } from "./config.js";
 
 const cfg = rawConfig as CatalogConfig;
 
@@ -37,6 +37,9 @@ export const config = {
 
   // Image layout
   imageOrientation: (cfg.imageOrientation ?? 'landscape') as ImageOrientation,
+
+  // Card layout
+  cardLayout: (cfg.cardLayout ?? 'masonry') as CardLayout,
 };
 
 export type ResolvedConfig = typeof config;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,5 @@
 export type ImageOrientation = 'landscape' | 'portrait' | 'none'
+export type CardLayout = 'masonry' | 'grid'
 
 export interface FilterDimension {
   cloud: boolean
@@ -28,4 +29,5 @@ export interface CatalogConfig {
   siteUrl?: string
   customCss?: string
   imageOrientation?: ImageOrientation
+  cardLayout?: CardLayout
 }

--- a/src/lib/filters.test.ts
+++ b/src/lib/filters.test.ts
@@ -8,6 +8,7 @@ import {
   getCosts,
 } from "./filters.js";
 import type { Post } from "./posts.js";
+import type { ImageOrientation } from "./config.js";
 
 function makePost(overrides: Partial<Post> & { slug: string }): Post {
   return {
@@ -28,6 +29,7 @@ function makePost(overrides: Partial<Post> & { slug: string }): Post {
     body: "",
     featured: false,
     sort_priority: null,
+    imageOrientation: null,
     meta: {},
     ...overrides,
   };
@@ -190,17 +192,15 @@ describe("applyFilters", () => {
 // ─── sortPosts ────────────────────────────────────────────────────────────────
 
 describe("sortPosts", () => {
-  it("featured posts appear before non-featured regardless of sort", () => {
-    for (const sort of ["newest", "oldest", "az", "za"] as const) {
-      const result = sortPosts(POSTS, sort);
-      const firstNonFeatured = result.findIndex((p) => !p.featured);
-      const lastFeatured = result.map((p) => p.featured).lastIndexOf(true);
-      expect(lastFeatured).toBeLessThan(firstNonFeatured);
-    }
+  it("featured posts appear before non-featured", () => {
+    const result = sortPosts(POSTS);
+    const firstNonFeatured = result.findIndex((p) => !p.featured);
+    const lastFeatured = result.map((p) => p.featured).lastIndexOf(true);
+    expect(lastFeatured).toBeLessThan(firstNonFeatured);
   });
 
   it("featured group ordered by sort_priority ascending", () => {
-    const result = sortPosts(POSTS, "newest");
+    const result = sortPosts(POSTS);
     const featured = result.filter((p) => p.featured);
     expect(featured[0].slug).toBe("featured-hi");
     expect(featured[1].slug).toBe("featured-lo");
@@ -208,32 +208,22 @@ describe("sortPosts", () => {
 
   it("sort_priority has no effect on non-featured items", () => {
     const noFeatured = POSTS.filter((p) => !p.featured);
-    const result = sortPosts(noFeatured, "newest");
+    const result = sortPosts(noFeatured);
     result.forEach((p) => expect(p.featured).toBe(false));
   });
 
-  it("newest sorts non-featured by date descending", () => {
-    const result = sortPosts(POSTS, "newest").filter((p) => !p.featured);
+  it("non-featured posts sorted by date descending", () => {
+    const result = sortPosts(POSTS).filter((p) => !p.featured);
     const dates = result.map((p) => p.date);
     expect(dates).toEqual([...dates].sort((a, b) => b.localeCompare(a)));
   });
 
-  it("oldest sorts non-featured by date ascending", () => {
-    const result = sortPosts(POSTS, "oldest").filter((p) => !p.featured);
-    const dates = result.map((p) => p.date);
-    expect(dates).toEqual([...dates].sort((a, b) => a.localeCompare(b)));
-  });
-
-  it("az sorts non-featured by name ascending", () => {
-    const result = sortPosts(POSTS, "az").filter((p) => !p.featured);
-    const names = result.map((p) => p.name ?? "");
-    expect(names).toEqual([...names].sort((a, b) => a.localeCompare(b)));
-  });
-
-  it("za sorts non-featured by name descending", () => {
-    const result = sortPosts(POSTS, "za").filter((p) => !p.featured);
-    const names = result.map((p) => p.name ?? "");
-    expect(names).toEqual([...names].sort((a, b) => b.localeCompare(a)));
+  it("posts without date prefix fall back to 1970-01-01 and sort last", () => {
+    const undated = makePost({ slug: "undated", date: "1970-01-01" });
+    const dated = makePost({ slug: "dated", date: "2024-06-01" });
+    const result = sortPosts([undated, dated]);
+    expect(result[0].slug).toBe("dated");
+    expect(result[1].slug).toBe("undated");
   });
 });
 

--- a/src/lib/filters.ts
+++ b/src/lib/filters.ts
@@ -1,13 +1,10 @@
 import type { Post } from './posts.js'
 
-export type SortOption = 'newest' | 'oldest' | 'az' | 'za'
-
 export interface FilterState {
   category: string
   author: string
   genre: string
   cost: string
-  sort: SortOption
 }
 
 export const DEFAULT_FILTER_STATE: FilterState = {
@@ -15,7 +12,6 @@ export const DEFAULT_FILTER_STATE: FilterState = {
   author: 'all',
   genre: 'all',
   cost: 'all',
-  sort: 'newest',
 }
 
 function normalize(s: string | null | undefined): string {
@@ -35,7 +31,7 @@ export function applyFilters(
   })
 }
 
-export function sortPosts(posts: Post[], sort: SortOption): Post[] {
+export function sortPosts(posts: Post[]): Post[] {
   const featured = [...posts.filter(p => p.featured)].sort((a, b) => {
     const pa = a.sort_priority ?? Infinity
     const pb = b.sort_priority ?? Infinity
@@ -43,14 +39,9 @@ export function sortPosts(posts: Post[], sort: SortOption): Post[] {
     return b.date.localeCompare(a.date)
   })
 
-  const rest = [...posts.filter(p => !p.featured)].sort((a, b) => {
-    switch (sort) {
-      case 'newest': return b.date.localeCompare(a.date)
-      case 'oldest': return a.date.localeCompare(b.date)
-      case 'az':     return normalize(a.name).localeCompare(normalize(b.name))
-      case 'za':     return normalize(b.name).localeCompare(normalize(a.name))
-    }
-  })
+  const rest = [...posts.filter(p => !p.featured)].sort((a, b) =>
+    b.date.localeCompare(a.date)
+  )
 
   return [...featured, ...rest]
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -8,7 +8,6 @@
   import TagCloud from '$lib/TagCloud.svelte'
   import Pagination from '$lib/Pagination.svelte'
   import { sortPosts } from '$lib/filters.js'
-  import type { SortOption } from '$lib/filters.js'
 
   const { data } = $props()
 
@@ -35,7 +34,6 @@
   let filterCost = $state('all')
   let filterTag = $state('all')
   let filterQuery = $state('')
-  let sort = $state<SortOption>('newest')
   let currentPage = $state(1)
 
   let pagefindReady = $state(false)
@@ -133,7 +131,6 @@
     filterCost = p.get('cost') ?? 'all'
     filterTag = p.get('tag') ?? 'all'
     filterQuery = p.get('q') ?? ''
-    sort = (p.get('sort') ?? 'newest') as SortOption
   }
 
   function writeUrlParams() {
@@ -144,7 +141,6 @@
     if (filterCost !== 'all') p.set('cost', filterCost)
     if (filterTag !== 'all') p.set('tag', filterTag)
     if (filterQuery) p.set('q', filterQuery)
-    if (sort !== 'newest') p.set('sort', sort)
     const qs = p.toString()
     history.replaceState(history.state, '', qs ? `?${qs}` : location.pathname)
   }
@@ -156,7 +152,7 @@
 
   $effect(() => {
     pagefindReady
-    filterCategory; filterAuthor; filterGenre; filterCost; filterTag; filterQuery; sort
+    filterCategory; filterAuthor; filterGenre; filterCost; filterTag; filterQuery
     if (!pagefindReady) return
     untrack(() => {
       writeUrlParams()
@@ -166,7 +162,7 @@
   })
 
   const pageSize = $derived(data.config.postsPerPage)
-  const sorted = $derived(sortPosts(allPosts, sort))
+  const sorted = $derived(sortPosts(allPosts))
   const totalPages = $derived(Math.max(1, Math.ceil(sorted.length / pageSize)))
   const paginated = $derived(
     sorted.slice((currentPage - 1) * pageSize, currentPage * pageSize)
@@ -233,7 +229,6 @@
         bind:author={filterAuthor}
         bind:genre={filterGenre}
         bind:cost={filterCost}
-        bind:sort
         show={data.config.showFilterBar}
         showCost={data.config.showCost}
       />

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,8 @@
 import '@testing-library/jest-dom'
+
+// jsdom does not implement ResizeObserver; stub it for component tests.
+global.ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}

--- a/starter-template/README.md
+++ b/starter-template/README.md
@@ -23,7 +23,7 @@ npm run dev       # preview at http://localhost:5173
 
 Each resource is a Markdown file with YAML frontmatter in `posts/`.
 
-**Filename format:** `YYYY-MM-DD-slug.md`
+**Filename format:** `slug.md` — or `YYYY-MM-DD-slug.md` if you want to control sort order by publication date.
 
 ```yaml
 ---
@@ -71,11 +71,13 @@ Posts can live directly in `posts/` or in any subdirectory:
 
 ```sh
 posts/
-  2024-01-01-my-adventure.md        ← flat
-  2024-01-02-my-system.md           ← flat
+  my-adventure.md                   ← flat, no date
+  2024-01-02-my-system.md           ← flat, with date prefix for sort order
   zines/
-    2024-01-03-my-zine.md           ← in a subdir
+    my-zine.md                      ← in a subdir
 ```
+
+Posts with a `YYYY-MM-DD-` prefix sort before undated posts (newest date first). Undated posts sort after all dated ones.
 
 Subdirectory names have no effect on categories. Categories come only from the `category:` field in each post's frontmatter. Organize subdirectories however makes sense for you — the catalog ignores the folder structure.
 
@@ -89,11 +91,19 @@ export default {
   // description: "",
   // siteUrl: "https://username.github.io/my-catalog",
   // theme: "vintage",        // cerberus | wintry | vintage | crimson | pine | modern
+  // cardLayout: 'masonry',   // masonry (default) | grid
   // postsPerPage: 24,
   // imageOrientation: 'landscape',  // landscape | portrait | none
   // showCost: false,
 }
 ```
+
+`cardLayout` controls how cards are arranged on the catalog page:
+
+| Value               | Behavior                                                     |
+| ------------------- | ------------------------------------------------------------- |
+| `masonry` (default) | Variable-height cards; gaps collapse. Best for mixed content. |
+| `grid`              | Uniform rows; all cards in a row share the same height.       |
 
 `imageOrientation` controls how cover images are displayed on cards and resource pages. Set it to match the shape of your cover images:
 

--- a/starter-template/gorlab.config.js
+++ b/starter-template/gorlab.config.js
@@ -29,8 +29,22 @@ export default {
   // Use this to add custom fonts or override specific styles.
   // customCss: "/my-styles.css",
 
+  // cardLayout: controls how resource cards are arranged on the catalog page.
+  //   'masonry' (default) — variable-height cards; gaps collapse naturally.
+  //                         Cards are ordered left-to-right in date order.
+  //                         Best for catalogs with mixed summary lengths or
+  //                         mixed imageOrientation values.
+  //   'grid'              — uniform rows; every card in a row shares the same
+  //                         height. Best when cards are visually consistent.
+  // cardLayout: 'masonry',
+
   // ── Content display ───────────────────────────────────────────────────────
   // postsPerPage: 24,
+
+  // Post filenames: posts/<category>/slug.md
+  // Optional: prefix with a publication date to control sort order —
+  //   posts/<category>/YYYY-MM-DD-slug.md
+  // Posts without a date prefix sort after all dated posts.
 
   // imageOrientation: controls how cover images are displayed across cards and
   // resource pages. Match this to the shape of your cover images.


### PR DESCRIPTION
Adds a `cardLayout` config option ('masonry' | 'grid', default 'masonry'). Masonry uses CSS Grid with per-card row-span measurement and a ResizeObserver so cards pack left-to-right without gaps on resize.

Removes the sort UI entirely — ordering is now silent date-descending (filename prefix), with featured posts pinned by sort_priority. Operators who want chronological order use YYYY-MM-DD- filename prefixes; undated posts fall to the bottom.