### PR TITLE
task: remove hard-coded image orientation from cards that caused clipping

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ src/
     ├── catalog.ts             # reads oddments.config.js, applies defaults
     ├── config.ts              # TypeScript interfaces (CatalogConfig, CustomField, …)
     ├── CardGrid.svelte        # responsive grid, empty state
-    ├── ExhibitCard.svelte    # card with cover image / gradient placeholder
+    ├── ExhibitCard.svelte     # card with optional natural-ratio cover image
     ├── FilterBar.svelte       # dropdown filters + sort select
     ├── TagCloud.svelte        # category pill buttons
     ├── SearchInput.svelte     # text search input

--- a/oddments.config.js
+++ b/oddments.config.js
@@ -37,7 +37,7 @@ export default {
   //   'masonry' (default) — variable-height cards; gaps collapse naturally.
   //                         Cards are ordered left-to-right in date order.
   //                         Best for catalogs with mixed summary lengths or
-  //                         mixed imageOrientation values.
+  //                         mixed cover image dimensions.
   //   'grid'              — uniform rows; every card in a row shares the same
   //                         height. Best when cards are visually consistent.
   // cardLayout: 'masonry',
@@ -50,12 +50,12 @@ export default {
   //   oddments/<category>/YYYY-MM-DD-slug.md
   // Exhibits without a date prefix sort after all dated exhibits.
 
-  // imageOrientation: controls how cover images are displayed across cards and
-  // exhibit pages. Match this to the shape of your cover images.
+  // imageOrientation: controls exhibit page cover layout and whether cover
+  // images are shown. Cards always use the cover image's natural dimensions.
   //   'landscape' (default) — wide images (e.g. A5/half-letter landscape).
-  //                           Cards use a 3:2 box. Exhibit page: image above text.
+  //                           Exhibit page: image above text.
   //   'portrait'            — tall images (e.g. A5/half-letter portrait, book covers).
-  //                           Cards use a 2:3 box. Exhibit page: image left, text right.
+  //                           Exhibit page: image left, text right.
   //   'none'                — no cover images; content fills full width everywhere.
   // Individual exhibits can override this with imageOrientation: in their frontmatter.
   // imageOrientation: 'landscape',

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
     "build": "svelte-kit sync && vite build && (pagefind --site build --glob \"exhibit/**/*.html\" && cp -r build/pagefind .svelte-kit/output/client/pagefind || echo \"No exhibit pages — search index skipped\")",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
-    "test:unit": "vitest run",
+    "test:unit": "vitest run --project unit",
+    "test:storybook": "vitest run --project storybook",
     "test:e2e": "playwright test",
-    "test": "npm run test:unit && npm run test:e2e",
+    "test": "npm run test:unit && npm run test:storybook && npm run test:e2e",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
   },

--- a/src/lib/ExhibitCard.svelte
+++ b/src/lib/ExhibitCard.svelte
@@ -10,21 +10,6 @@
         return Array.isArray(val) ? val : [val];
     }
 
-    function hashString(s: string): number {
-        let h = 0;
-        for (let i = 0; i < s.length; i++) {
-            h = (Math.imul(31, h) + s.charCodeAt(i)) | 0;
-        }
-        return Math.abs(h);
-    }
-
-    function placeholderGradient(name: string): string {
-        const h = hashString(name);
-        const hue1 = h % 360;
-        const hue2 = (h + 137) % 360;
-        return `linear-gradient(135deg, color-mix(in oklch, var(--color-surface-200-800) 75%, oklch(0.5 0.15 ${hue1}) 25%), color-mix(in oklch, var(--color-surface-300-700) 70%, oklch(0.5 0.15 ${hue2}) 30%))`;
-    }
-
     const categories = $derived(toArray(exhibit.category));
     const author = $derived(toArray(exhibit.author).join(", "));
     const orientation = $derived(exhibit.imageOrientation ?? config.imageOrientation);
@@ -34,11 +19,6 @@
             ? `${base}${exhibit["cover-image"]}`
             : (exhibit["cover-image"] ?? ""),
     );
-    const coverStyle = $derived(
-        hasCover
-            ? ""
-            : `background: ${placeholderGradient(exhibit.name ?? exhibit.slug)};`,
-    );
 </script>
 
 <article
@@ -46,23 +26,18 @@
         ? 'ring-1 ring-primary-500'
         : ''}"
 >
-    <!-- Cover image or gradient placeholder -->
-    {#if orientation !== 'none'}
+    {#if hasCover && orientation !== 'none'}
         <a
             href={`${base}/exhibit/${exhibit.slug}/`}
-            class="block {orientation === 'portrait' ? 'aspect-2/3' : 'aspect-3/2'} overflow-hidden shrink-0"
+            class="block overflow-hidden shrink-0"
             aria-label={exhibit.name ?? exhibit.slug}
         >
-            {#if hasCover}
-                <img
-                    src={coverSrc}
-                    alt={exhibit.name}
-                    class="w-full h-full object-cover"
-                    loading="lazy"
-                />
-            {:else}
-                <div class="w-full h-full" style={coverStyle}></div>
-            {/if}
+            <img
+                src={coverSrc}
+                alt={exhibit.name}
+                class="w-full h-auto"
+                loading="lazy"
+            />
         </a>
     {/if}
 

--- a/src/lib/ExhibitCard.test.ts
+++ b/src/lib/ExhibitCard.test.ts
@@ -22,6 +22,7 @@ function makeExhibit(overrides: Partial<Exhibit> = {}): Exhibit {
     body: "",
     featured: false,
     sort_priority: null,
+    imageOrientation: null,
     meta: {},
     ...overrides,
   };
@@ -53,7 +54,7 @@ test("links to the exhibit detail page", () => {
 });
 
 test("renders img tag when cover-image is set", () => {
-  render(ExhibitCard, {
+  const { container } = render(ExhibitCard, {
     exhibit: makeExhibit({
       "cover-image": "https://example.com/cover.png",
       name: "Covered Game",
@@ -62,11 +63,45 @@ test("renders img tag when cover-image is set", () => {
   const img = screen.getByRole("img", { name: "Covered Game" });
   expect(img).toBeInTheDocument();
   expect(img).toHaveAttribute("src", "https://example.com/cover.png");
+  expect(img).toHaveClass("w-full");
+  expect(img).toHaveClass("h-auto");
+  expect(img).not.toHaveClass("object-cover");
+  expect(container.querySelector(".aspect-3\\/2")).not.toBeInTheDocument();
+  expect(container.querySelector(".aspect-2\\/3")).not.toBeInTheDocument();
 });
 
-test("renders placeholder div (no img) when cover-image is null", () => {
-  render(ExhibitCard, { exhibit: makeExhibit({ "cover-image": null }) });
+test("renders no media area when cover-image is null", () => {
+  const { container } = render(ExhibitCard, {
+    exhibit: makeExhibit({ "cover-image": null }),
+  });
   expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  expect(container.querySelector('a[aria-label="Test Exhibit"]')).not.toBeInTheDocument();
+  expect(container.querySelector(".aspect-3\\/2")).not.toBeInTheDocument();
+  expect(container.querySelector(".aspect-2\\/3")).not.toBeInTheDocument();
+});
+
+test("renders no media area when imageOrientation is none", () => {
+  const { container } = render(ExhibitCard, {
+    exhibit: makeExhibit({
+      "cover-image": "https://example.com/cover.png",
+      imageOrientation: "none",
+    }),
+  });
+  expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  expect(container.querySelector('a[aria-label="Test Exhibit"]')).not.toBeInTheDocument();
+});
+
+test("card image orientation does not force a fixed card aspect ratio", () => {
+  const { container } = render(ExhibitCard, {
+    exhibit: makeExhibit({
+      "cover-image": "https://example.com/cover.png",
+      imageOrientation: "portrait",
+    }),
+  });
+  const mediaLink = container.querySelector('a[aria-label="Test Exhibit"]');
+  expect(mediaLink).toBeInTheDocument();
+  expect(mediaLink?.className).not.toContain("aspect-2/3");
+  expect(mediaLink?.className).not.toContain("aspect-3/2");
 });
 
 test("featured exhibit has ring class on article", () => {

--- a/src/stories/molecules/ExhibitCard.stories.svelte
+++ b/src/stories/molecules/ExhibitCard.stories.svelte
@@ -9,7 +9,7 @@
       imageOrientation: {
         control: 'radio',
         options: ['landscape', 'portrait', 'none'] satisfies ImageOrientation[],
-        description: 'Image aspect ratio and layout. Mirrors the per-exhibit frontmatter field.',
+        description: 'Controls whether card media is shown. Exhibit pages still use this for layout.',
       },
     },
     args: {
@@ -21,6 +21,11 @@
 <script lang="ts">
   import ExhibitCard from '$lib/ExhibitCard.svelte';
   import type { Exhibit } from '$lib/oddments.js';
+
+  const landscapeCover =
+    'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 720"%3E%3Crect width="1200" height="720" fill="%232c5f5d"/%3E%3Ccircle cx="920" cy="190" r="150" fill="%23f0c46b"/%3E%3Cpath d="M0 520 260 350l170 105 210-190 250 255 150-120 160 120v200H0z" fill="%23d95d39"/%3E%3C/svg%3E';
+  const portraitCover =
+    'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 1100"%3E%3Crect width="720" height="1100" fill="%23344156"/%3E%3Cpath d="M95 150h530v800H95z" fill="%23efe3c8"/%3E%3Cpath d="M155 245h410v85H155zm0 145h305v45H155zm0 75h360v45H155zm0 75h260v45H155z" fill="%2381465b"/%3E%3Ccircle cx="360" cy="760" r="120" fill="%232c8c77"/%3E%3C/svg%3E';
 
   const base: Exhibit = {
     slug: 'the-black-hack',
@@ -34,7 +39,7 @@
     genre: 'fantasy',
     cost: 'PWYW',
     license: 'CC BY 4.0',
-    'cover-image': null,
+    'cover-image': landscapeCover,
     tags: ['osr', 'dungeon-crawl'],
     stats: null,
     subtexts: [],
@@ -46,7 +51,7 @@
   };
 </script>
 
-<!-- Default: toggle imageOrientation in the Controls panel -->
+<!-- Default: image keeps its natural dimensions on cards -->
 <Story name="Default">
   {#snippet template(args)}
     <div class="w-56">
@@ -55,17 +60,17 @@
   {/snippet}
 </Story>
 
-<!-- Landscape: 3:2 image box — for wide cover images (A5/half-letter landscape) -->
+<!-- Landscape: wide image renders at its natural ratio on cards -->
 <Story name="Landscape">
   <div class="w-56">
-    <ExhibitCard exhibit={{ ...base, imageOrientation: 'landscape' }} />
+    <ExhibitCard exhibit={{ ...base, 'cover-image': landscapeCover, imageOrientation: 'landscape' }} />
   </div>
 </Story>
 
-<!-- Portrait: 2:3 image box — for tall cover images (A5/half-letter portrait, book covers) -->
+<!-- Portrait: tall image renders at its natural ratio on cards -->
 <Story name="Portrait">
   <div class="w-56">
-    <ExhibitCard exhibit={{ ...base, imageOrientation: 'portrait' }} />
+    <ExhibitCard exhibit={{ ...base, 'cover-image': portraitCover, imageOrientation: 'portrait' }} />
   </div>
 </Story>
 
@@ -73,6 +78,13 @@
 <Story name="None">
   <div class="w-56">
     <ExhibitCard exhibit={{ ...base, imageOrientation: 'none' }} />
+  </div>
+</Story>
+
+<!-- MissingCover: no placeholder media box is rendered -->
+<Story name="MissingCover">
+  <div class="w-56">
+    <ExhibitCard exhibit={{ ...base, 'cover-image': null }} />
   </div>
 </Story>
 
@@ -90,11 +102,11 @@
   </div>
 </Story>
 
-<!-- ThreeUp: mixed orientations in a grid to preview per-exhibit overrides -->
+<!-- ThreeUp: mixed image dimensions in a grid -->
 <Story name="ThreeUp">
   <div class="grid grid-cols-3 gap-6 max-w-2xl">
-    <ExhibitCard exhibit={{ ...base, imageOrientation: 'landscape' }} />
-    <ExhibitCard exhibit={{ ...base, slug: 'knave', name: 'Knave', author: 'Ben Milton', featured: true, imageOrientation: 'portrait' }} />
-    <ExhibitCard exhibit={{ ...base, slug: 'maze-rats', name: 'Maze Rats', author: 'Ben Milton', category: ['Toolkit'], summary: null, imageOrientation: 'none' }} />
+    <ExhibitCard exhibit={{ ...base, 'cover-image': landscapeCover, imageOrientation: 'landscape' }} />
+    <ExhibitCard exhibit={{ ...base, 'cover-image': portraitCover, slug: 'knave', name: 'Knave', author: 'Ben Milton', featured: true, imageOrientation: 'portrait' }} />
+    <ExhibitCard exhibit={{ ...base, 'cover-image': null, slug: 'maze-rats', name: 'Maze Rats', author: 'Ben Milton', category: ['Toolkit'], summary: null }} />
   </div>
 </Story>

--- a/starter-template/oddments.config.js
+++ b/starter-template/oddments.config.js
@@ -41,7 +41,7 @@ export default {
   //   'masonry' (default) — variable-height cards; gaps collapse naturally.
   //                         Cards are ordered left-to-right in date order.
   //                         Best for catalogs with mixed summary lengths or
-  //                         mixed imageOrientation values.
+  //                         mixed cover image dimensions.
   //   'grid'              — uniform rows; every card in a row shares the same
   //                         height. Best when cards are visually consistent.
   // cardLayout: 'masonry',
@@ -54,12 +54,12 @@ export default {
   //   oddments/<category>/YYYY-MM-DD-slug.md
   // Exhibits without a date prefix sort after all dated exhibits.
 
-  // imageOrientation: controls how cover images are displayed across cards and
-  // exhibit pages. Match this to the shape of your cover images.
+  // imageOrientation: controls exhibit page cover layout and whether cover
+  // images are shown. Cards always use the cover image's natural dimensions.
   //   'landscape' (default) — wide images (e.g. A5/half-letter landscape).
-  //                           Cards use a 3:2 box. Exhibit page: image above text.
+  //                           Exhibit page: image above text.
   //   'portrait'            — tall images (e.g. A5/half-letter portrait, book covers).
-  //                           Cards use a 2:3 box. Exhibit page: image left, text right.
+  //                           Exhibit page: image left, text right.
   //   'none'                — no cover images; content fills full width everywhere.
   // Individual exhibits can override this with imageOrientation: in their frontmatter.
   // imageOrientation: 'landscape',


### PR DESCRIPTION
- cards no longer use hard-coded aspect ratios, images should no longer clip and tile correctly in masonry layout
- fixes a vitest issue where two tests were running in parallel instead of in sequence